### PR TITLE
Remove the domain parameter from the cloud-init TF configuration

### DIFF
--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -9,7 +9,6 @@ data "template_cloudinit_config" "cloud_init_tasks" {
     content = templatefile(
       "${path.module}/scripts/setup_freeipa.sh", {
         admin_pw = var.admin_pw
-        domain   = var.domain
         hostname = var.hostname
         realm    = var.realm
     })


### PR DESCRIPTION
This parameter is not used, and in fact causes an error at apply time.