### PR TITLE
Remove "domain" from Usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ module "ipa" {
   admin_pw                    = "thepassword"
   associate_public_ip_address = true
   client_security_group_id    = aws.aws_security_group.client_sg.id
-  domain                      = "example.com"
   hostname                    = "client1.example.com"
   private_reverse_zone_id     = aws_route53_zone.client_private_reverse_zone.zone_id
   private_zone_id             = aws_route53_zone.private_zone.zone_id


### PR DESCRIPTION
The `domain` variable does not exist anymore, so remove it from the Usage example in the README.